### PR TITLE
タイムゾーンの表示を日本時間に変更

### DIFF
--- a/components/Date.Text.tsx
+++ b/components/Date.Text.tsx
@@ -1,0 +1,8 @@
+// components/DateText.tsx
+// utc表示から日本時間にする
+import React from "react";
+import { formatDateToJST } from "@/lib/utils/date";
+
+export function DateText({ date }: { date: string | Date }) {
+  return <>{formatDateToJST(date)}</>;
+}

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -35,7 +35,7 @@ export default function Header({ currentLoginUserData }: HeaderProps) {
 
         {/* アンケート */}
         <Link
-          href="https://docs.google.com/forms/…"
+          href="https://forms.gle/JF95dpZ8izBrQc7C8"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center justify-center h-8 w-8 rounded-full hover:bg-muted transition-colors"

--- a/components/layouts/LeftSidebar.tsx
+++ b/components/layouts/LeftSidebar.tsx
@@ -86,7 +86,7 @@ export default function LeftSidebar({
 
       <div className="mt-auto pt-4 border-t">
         <Link
-          href="https://docs.google.com/forms/d/e/1FAIpQLSdLbVn1Wwbzfa9Zdq6ZjAnrrRMzur-ZKhu4-EXrmT8Q8__p0g/viewform"
+          href="https://forms.gle/JF95dpZ8izBrQc7C8"
           className="block"
           target="_blank"
           rel="noopener noreferrer"

--- a/components/rankings/CommentSection.tsx
+++ b/components/rankings/CommentSection.tsx
@@ -10,6 +10,7 @@ import {
   useRankingListComments,
   RankingComment,
 } from "@/lib/hooks/useRankingListComments";
+import { DateText } from "@/components/Date.Text"
 
 interface Props {
   listId: string;
@@ -64,7 +65,7 @@ export default function CommentSection({ listId }: Props) {
                 @{c.user.username}
               </span>
               <span className="ml-auto text-xs text-muted-foreground">
-                {new Date(c.createdAt).toLocaleString()}
+              <DateText date={c.createdAt} />
               </span>
             </Link>
             <p className="mb-6">{c.content}</p> {/* 下に余白を確保 */}

--- a/components/trends/CommentSection.tsx
+++ b/components/trends/CommentSection.tsx
@@ -10,6 +10,7 @@ import {
   useAverageItemComments,
   AverageComment,
 } from '@/lib/hooks/useAverageItemComments'
+import { DateText } from '@/components/Date.Text'
 
 interface Props {
   subject: string
@@ -63,7 +64,7 @@ export default function CommentSection({ subject }: Props) {
                 @{c.user.username}
               </span>
               <span className="ml-auto text-xs text-muted-foreground">
-                {new Date(c.createdAt).toLocaleString()}
+              <DateText date={c.createdAt} />
               </span>
             </Link>
             <p className="mb-6">{c.content}</p>

--- a/components/trends/NewList.tsx
+++ b/components/trends/NewList.tsx
@@ -1,6 +1,7 @@
 // components/trends/NewList.tsx
 import React from "react";
 import Link from "next/link";
+import { DateText } from "@/components/Date.Text";
 
 export interface NewListEntry {
   id: string;
@@ -28,7 +29,7 @@ export default function NewList({ lists, isLoading, isError }: Props) {
           <Link href={`/rankings/${item.id}`} className="block h-full">
             <h3 className="font-bold text-base">{item.subject}</h3>
             <div className="text-sm text-muted-foreground mt-1">
-              {new Date(item.createdAt).toLocaleString()}
+             <DateText date={item.createdAt} />
             </div>
           </Link>
         </li>

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,17 @@
+// lib/utils/date.ts
+import { format, toZonedTime } from "date-fns-tz";
+
+// 表示フォーマット。好みで書式は変えてください。
+const DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
+const TIME_ZONE = "Asia/Tokyo";
+
+/**
+ * ISO 文字列 or Date オブジェクトを受け取り、
+ * Asia/Tokyo のタイムゾーンでフォーマットされた文字列を返す。
+ */
+export function formatDateToJST(date: string | Date): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  // UTC→Asia/Tokyo に変換
+  const zoned = toZonedTime(d, TIME_ZONE);
+  return format(zoned, DATE_FORMAT, { timeZone: TIME_ZONE });
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,11 @@
+// next.config.js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  env: {
+    // Node.js／サーバーのタイムゾーンを日本時間に
+    TZ: "Asia/Tokyo",
+  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.399.0",
         "next": "15.3.0",
@@ -4086,6 +4087,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.399.0",
     "next": "15.3.0",


### PR DESCRIPTION
コンポーネントdate-fns と date-fns-tz の導入
npm install date-fns date-fns-tz を実行し、タイムゾーン付きフォーマット用のライブラリを追加

lib/utils/date.ts の作成・修正

formatDateToJST(date) ユーティリティを実装

import { format, toZonedTime } from "date-fns-tz" を使って UTC→Asia/Tokyo 変換＆フォーマット

components/DateText.tsx コンポーネント追加

formatDateToJST() をラップした小コンポーネントを用意し、各所で呼び出せるように

既存の toLocaleString() を一括置換

NewList、コメント欄、フィードアイテムなど、日時を表示していた箇所を <DateText date={…} /> に書き換え

next.config.js に env.TZ = "Asia/Tokyo" を追加

サーバーサイド（SSR）プロセスのデフォルトタイムゾーンを補助的に設定

これらにより、クライアント／サーバー問わず全ページで常に日本時間（JST）表示が統一







