### PR TITLE
ランキング作成・編集時の入力補助機能

### DIFF
--- a/app/api/suggestions/items.ts
+++ b/app/api/suggestions/items.ts
@@ -1,0 +1,26 @@
+// pages/api/suggestions/items.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/lib/client";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string[]>
+) {
+  const { subject = "", prefix = "", limit = "10" } = req.query;
+  const s = String(subject);
+  const p = String(prefix);
+  const l = Number(limit);
+  if (!s) return res.status(400).json([]);
+  const whereClause: any = {
+    rankingList: { subject: s, status: "PUBLISHED" },
+  };
+  if (p) whereClause.itemName = { startsWith: p };
+  const items = await prisma.rankedItem.findMany({
+    where: whereClause,
+    distinct: ["itemName"],
+    select: { itemName: true },
+    orderBy: { itemName: "asc" },
+    take: Math.min(l, 10),
+  });
+  res.status(200).json(items.map(i => i.itemName));
+}

--- a/app/api/suggestions/subjects.ts
+++ b/app/api/suggestions/subjects.ts
@@ -1,0 +1,21 @@
+// pages/api/suggestions/subjects.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/lib/client";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string[]>
+) {
+  const { prefix = "", limit = "10" } = req.query;
+  const p = String(prefix);
+  const l = Number(limit);
+  if (p.length < 3) return res.status(200).json([]);
+  const subjects = await prisma.rankingList.findMany({
+    where: { status: "PUBLISHED", subject: { startsWith: p } },
+    distinct: ["subject"],
+    select: { subject: true },
+    orderBy: { subject: "asc" },
+    take: Math.min(l, 10),
+  });
+  res.status(200).json(subjects.map(s => s.subject));
+}

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,6 +1,22 @@
 // components/Icons.tsx
 import { SVGProps } from "react";
 
+export const ChevronsUpDown = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="m7 15 5 5 5-5" />
+    <path d="m7 9 5-5 5 5" />
+  </svg>
+);
+
 export const LightBulbIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/components/rankings/EditableRankedItem.tsx
+++ b/components/rankings/EditableRankedItem.tsx
@@ -1,14 +1,15 @@
 //components/rankings/EditableRankedItem.tsx
 "use client";
 
-import { useRef, type ChangeEvent } from "react";
-import { Input } from "@/components/ui/input";
+import { useRef, type ChangeEvent,useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { ImagePlus, TrashIcon, XIcon, GripVertical } from "@/components/Icons";
+import { ImagePlus, TrashIcon, XIcon, GripVertical,ChevronsUpDown } from "@/components/Icons";
 import Image from "next/image";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Combobox } from "@headlessui/react";
+import { useItemSuggestions } from "@/lib/hooks/useItemSuggestions";
 
 export type EditableItem = {
   clientId: string;
@@ -21,6 +22,7 @@ export type EditableItem = {
 };
 
 interface Props {
+  subject: string;
   clientId: string;
   item: EditableItem;
   index: number;
@@ -38,6 +40,7 @@ interface Props {
 }
 
 export function EditableRankedItem({
+  subject,
   clientId,
   item,
   index,
@@ -54,6 +57,8 @@ export function EditableRankedItem({
     transition,
     isDragging,
   } = useSortable({ id: clientId });
+  const [itemQuery, setItemQuery] = useState(item.itemName);
+  const { options: itemOptions, isLoading: isItemLoading } =useItemSuggestions(subject, itemQuery);
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -72,110 +77,139 @@ export function EditableRankedItem({
     if (itemImageInputRef.current) itemImageInputRef.current.value = "";
   };
 
-  return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      className='flex items-start gap-3 p-3 bg-secondary/50 dark:bg-secondary/30 rounded relative border'
+return (
+  <li
+    ref={setNodeRef}
+    style={style}
+    {...attributes}
+    className="flex items-start gap-3 p-3 bg-secondary/50 dark:bg-secondary/30 rounded relative border"
+  >
+    {/* ドラッグハンドル */}
+    <button
+      {...listeners}
+      className="cursor-grab touch-none p-1 mt-6 text-muted-foreground hover:text-foreground"
+      title="ドラッグして並び替え"
+      type="button"
     >
-      {/* ドラッグハンドル */}
-      <button
-        {...listeners}
-        className='cursor-grab touch-none p-1 mt-6 text-muted-foreground hover:text-foreground'
-        title='ドラッグして並び替え'
-        type='button'
-      >
-        <GripVertical className='h-5 w-5' />
-      </button>
+      <GripVertical className="h-5 w-5" />
+    </button>
 
-      {/* 順位表示 */}
-      <span className='font-semibold w-8 text-center text-muted-foreground pt-7 whitespace-nowrap'>
-        {`${index + 1}位`}
-      </span>
+    {/* 順位表示 */}
+    <span className="font-semibold w-8 text-center text-muted-foreground pt-7 whitespace-nowrap">
+      {`${index + 1}位`}
+    </span>
 
-      {/* 画像アップロード／プレビュー */}
-      <div className='flex-shrink-0 pt-1'>
-        {item.previewUrl ? (
-          <div className='relative w-20 h-20 rounded border bg-muted'>
-            <Image
-              src={item.previewUrl}
-              alt={`${item.itemName || "Item"} preview`}
-              fill
-              className='object-cover rounded'
-            />
-            <Button
-              type='button'
-              variant='destructive'
-              size='icon'
-              className='absolute -top-2 -right-2 h-6 w-6 rounded-full z-10'
-              onClick={onRemoveImage}
-              disabled={isSaving}
-              title='画像削除'
-            >
-              <XIcon className='h-4 w-4' />
-            </Button>
-          </div>
-        ) : (
+    {/* 画像アップロード／プレビュー */}
+    <div className="flex-shrink-0 pt-1">
+      {item.previewUrl ? (
+        <div className="relative w-20 h-20 rounded border bg-muted">
+          <Image
+            src={item.previewUrl}
+            alt={`${item.itemName || "Item"} preview`}
+            fill
+            className="object-cover rounded"
+          />
           <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            className='w-20 h-20 flex flex-col items-center justify-center text-muted-foreground bg-background'
-            onClick={() => itemImageInputRef.current?.click()}
+            type="button"
+            variant="destructive"
+            size="icon"
+            className="absolute -top-2 -right-2 h-6 w-6 rounded-full z-10"
+            onClick={onRemoveImage}
             disabled={isSaving}
+            title="画像削除"
           >
-            <ImagePlus className='h-6 w-6 mb-1' />
-            <span className='text-xs'>画像選択</span>
+            <XIcon className="h-4 w-4" />
           </Button>
-        )}
-        <input
-          type='file'
-          accept='image/*'
-          ref={itemImageInputRef}
-          onChange={onFileChange}
-          className='hidden'
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-20 h-20 flex flex-col items-center justify-center text-muted-foreground bg-background"
+          onClick={() => itemImageInputRef.current?.click()}
           disabled={isSaving}
-        />
-      </div>
-
-      {/* アイテム入力 */}
-      <div className='flex-1 space-y-1 pt-1'>
-        <Input
-          value={item.itemName}
-          onChange={(e) =>
-            handleItemChange(clientId, "itemName", e.target.value)
-          }
-          placeholder={`${index + 1}位のアイテム名*`}
-          maxLength={100}
-          className='bg-background font-medium'
-          required
-          disabled={isSaving}
-        />
-        <Textarea
-          value={item.itemDescription ?? ""}
-          onChange={(e) =>
-            handleItemChange(clientId, "itemDescription", e.target.value)
-          }
-          placeholder='アイテムの説明・コメント（任意）'
-          rows={2}
-          maxLength={500}
-          className='text-sm bg-background'
-          disabled={isSaving}
-        />
-      </div>
-
-      {/* 削除ボタン */}
-      <Button
-        variant='ghost'
-        size='icon'
-        onClick={() => handleDeleteItem(clientId)}
-        title='アイテム削除'
+        >
+          <ImagePlus className="h-6 w-6 mb-1" />
+          <span className="text-xs">画像選択</span>
+        </Button>
+      )}
+      <input
+        type="file"
+        accept="image/*"
+        ref={itemImageInputRef}
+        onChange={onFileChange}
+        className="hidden"
         disabled={isSaving}
-        className='mt-1 text-muted-foreground hover:text-destructive'
+      />
+    </div>
+
+    {/* アイテム入力 */}
+    <div className="flex-1 space-y-1 pt-1">
+      <Combobox<string>
+        value={item.itemName}
+        onChange={(val: string) =>
+          handleItemChange(clientId, "itemName", val)
+        }
       >
-        <TrashIcon className='h-4 w-4' />
-      </Button>
-    </li>
-  );
+        <div className="relative">
+          <Combobox.Input
+            className="w-full bg-background font-medium"
+            placeholder={`${index + 1}位のアイテム名*`}
+            onChange={(e) => setItemQuery(e.target.value)}
+            displayValue={(val: string) => val}
+            value={itemQuery}
+            maxLength={100}
+            disabled={isSaving}
+          />
+          <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+            <ChevronsUpDown className="h-5 w-5 text-muted-foreground" />
+          </Combobox.Button>
+          <Combobox.Options className="absolute z-10 mt-1 w-full bg-popover shadow-md max-h-60 overflow-auto rounded-md">
+            {isItemLoading && <div className="p-2">読み込み中…</div>}
+            {!isItemLoading && itemOptions.length === 0 && (
+              <div className="p-2 text-muted-foreground">該当なし</div>
+            )}
+            {itemOptions.map((opt) => (
+              <Combobox.Option
+                key={opt}
+                value={opt}
+                className={({ active }) =>
+                  `cursor-pointer select-none p-2 ${
+                    active ? "bg-primary text-primary-foreground" : ""
+                  }`
+                }
+              >
+                {opt}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </div>
+      </Combobox>
+      <Textarea
+        value={item.itemDescription ?? ""}
+        onChange={(e) =>
+          handleItemChange(clientId, "itemDescription", e.target.value)
+        }
+        placeholder="アイテムの説明・コメント（任意）"
+        rows={2}
+        maxLength={500}
+        className="text-sm bg-background"
+        disabled={isSaving}
+      />
+    </div>
+
+    {/* 削除ボタン */}
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => handleDeleteItem(clientId)}
+      title="アイテム削除"
+      disabled={isSaving}
+      className="mt-1 text-muted-foreground hover:text-destructive"
+    >
+      <TrashIcon className="h-4 w-4" />
+    </Button>
+  </li>
+);
 }

--- a/lib/hooks/useDebounce.ts
+++ b/lib/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+// lib/hooks/useDebounce.ts
+
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debounced;
+}

--- a/lib/hooks/useItemSuggestions.ts
+++ b/lib/hooks/useItemSuggestions.ts
@@ -1,0 +1,27 @@
+// lib/hooks/useItemSuggestions.ts
+import useSWR from "swr";
+import { useDebounce } from "./useDebounce";
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export function useItemSuggestions(
+  subject: string,
+  query: string
+) {
+  const debounced = useDebounce(query, 300);
+  const shouldFetch = subject && debounced.length >= 1;
+  const prefixParam = debounced
+    ? `&prefix=${encodeURIComponent(debounced)}`
+    : "";
+  const key = shouldFetch
+    ? `/api/suggestions/items?subject=${encodeURIComponent(
+        subject
+      )}${prefixParam}`
+    : null;
+  const { data, error, isLoading } = useSWR<string[]>(key, fetcher);
+  return {
+    options: data ?? [],
+    isLoading,
+    isError: !!error,
+  };
+}

--- a/lib/hooks/useSubjectSuggestions.ts
+++ b/lib/hooks/useSubjectSuggestions.ts
@@ -1,0 +1,19 @@
+// lib/hooks/useSubjectSuggestions.ts
+import useSWR from "swr";
+import { useDebounce } from "./useDebounce";
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export function useSubjectSuggestions(query: string) {
+  const debounced = useDebounce(query, 300);
+  const shouldFetch = debounced.length >= 3;
+  const key = shouldFetch
+    ? `/api/suggestions/subjects?prefix=${encodeURIComponent(debounced)}`
+    : null;
+  const { data, error, isLoading } = useSWR<string[]>(key, fetcher);
+  return {
+    options: data ?? [],
+    isLoading,
+    isError: !!error,
+  };
+}


### PR DESCRIPTION
useDebounce フック作成
入力値を 300ms デバウンスする汎用フックを lib/hooks/useDebounce.ts に実装

useSubjectSuggestions フック作成
SWR＋デバウンスで /api/suggestions/subjects から公開済みランキングのタイトル候補を取得

useItemSuggestions フック作成
SWR＋デバウンスで /api/suggestions/items から選択済みタイトルに紐づくアイテム名候補を取得

API エンドポイント追加

pages/api/suggestions/subjects.ts（3文字以上の先頭一致・最大10件）

pages/api/suggestions/items.ts（タイトル＋先頭一致・最大10件）

NewRankingForm に Combobox を導入
Headless UI の <Combobox> でタイトル入力補助を実装し、読み込み中／該当なし表示も対応

EditableRankedItem に Combobox を導入
各アイテム名入力欄で候補ドロップダウンを実装し、Subject をプロップで受け取るよう修正

RankingEdit コンポーネント修正
編集フォームのタイトル欄にも Combobox を追加し、選択後にアイテム欄へスムーズに移行

パフォーマンス考慮
Prisma の startsWith＋distinct＋orderBy で B-tree インデックスを活用、DB 負荷を抑制しました。

備考：Combobox のジェネリック指定は修正方法がわからないので放置する