### PR TITLE
アイテムのスマホ表示修正

### DIFF
--- a/components/rankings/common/EditableRankedItem.tsx
+++ b/components/rankings/common/EditableRankedItem.tsx
@@ -70,7 +70,7 @@ export const EditableRankedItem: FC<Props> = ({
   const [itemQuery, setItemQuery] = useState(item.itemName);
   const [suggestEnabled, setSuggestEnabled] = useState(false);
 
-  // suggestEnabledがtrueのときのみ、空prefixでフェッチ
+  // suggestEnabledがtrueのときのみフェッチ
   const { options: itemOptions, isLoading: isItemLoading } =
     useItemSuggestions(subject, itemQuery, suggestEnabled);
 
@@ -99,141 +99,135 @@ export const EditableRankedItem: FC<Props> = ({
       ref={setNodeRef}
       style={style}
       {...attributes}
-      className="flex items-start gap-3 p-3 bg-secondary/50 dark:bg-secondary/30 rounded relative border"
+      // 小画面では縦積み、sm以上で横並び
+      className="flex flex-col sm:flex-row items-start gap-3 p-3 bg-secondary/50 dark:bg-secondary/30 rounded relative border"
     >
-      {/* ドラッグハンドル */}
-      <button
-        {...listeners}
-        className="cursor-grab touch-none p-1 mt-6 text-muted-foreground hover:text-foreground"
-        title="ドラッグして並び替え"
-        type="button"
-      >
-        <GripVertical className="h-5 w-5" />
-      </button>
-
-      {/* 順位表示 */}
-      <span className="font-semibold w-8 text-center text-muted-foreground pt-7 whitespace-nowrap">
-        {`${index + 1}位`}
-      </span>
-
-      {/* 画像アップロード／プレビュー */}
-      <div className="flex-shrink-0 pt-1">
-        {item.previewUrl ? (
-          <div className="relative w-20 h-20 rounded border bg-muted">
-            <Image
-              src={item.previewUrl}
-              alt={`${item.itemName || "Item"} preview`}
-              fill
-              className="object-cover rounded"
-            />
+      {/* 1行目：ドラッグ＆順位＆画像 */}
+      <div className="flex items-center gap-3 w-full sm:w-auto">
+        <button
+          {...listeners}
+          className="cursor-grab p-1 text-muted-foreground hover:text-foreground"
+          title="ドラッグして並び替え"
+          type="button"
+        >
+          <GripVertical className="h-5 w-5" />
+        </button>
+        <span className="font-semibold w-8 text-center text-muted-foreground">
+          {`${index + 1}位`}
+        </span>
+        <div className="flex-shrink-0">
+          {item.previewUrl ? (
+            <div className="relative w-20 h-20 rounded border bg-muted">
+              <Image
+                src={item.previewUrl}
+                alt={`${item.itemName || "Item"} preview`}
+                fill
+                className="object-cover rounded"
+              />
+              <Button
+                type="button"
+                variant="destructive"
+                size="icon"
+                className="absolute -top-2 -right-2 h-6 w-6 rounded-full z-10"
+                onClick={onRemoveImage}
+                disabled={isSaving}
+                title="画像削除"
+              >
+                <XIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
             <Button
               type="button"
-              variant="destructive"
-              size="icon"
-              className="absolute -top-2 -right-2 h-6 w-6 rounded-full z-10"
-              onClick={onRemoveImage}
+              variant="outline"
+              size="sm"
+              className="w-20 h-20 flex flex-col items-center justify-center text-muted-foreground bg-background"
+              onClick={() => itemImageInputRef.current?.click()}
               disabled={isSaving}
-              title="画像削除"
             >
-              <XIcon className="h-4 w-4" />
+              <ImagePlus className="h-6 w-6 mb-1" />
+              <span className="text-xs">画像選択</span>
             </Button>
-          </div>
-        ) : (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="w-20 h-20 flex flex-col items-center justify-center text-muted-foreground bg-background"
-            onClick={() => itemImageInputRef.current?.click()}
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            ref={itemImageInputRef}
+            onChange={onFileChange}
+            className="hidden"
             disabled={isSaving}
+          />
+        </div>
+      </div>
+
+      {/* 2行目：アイテム名＆説明＆削除ボタン */}
+      <div className="flex flex-col sm:flex-row items-start gap-3 w-full">
+        <div className="flex-1 space-y-1">
+          <Combobox
+            value={item.itemName}
+            onChange={(val: string) => {
+              handleItemChange(clientId, "itemName", val);
+              setItemQuery(val);
+            }}
           >
-            <ImagePlus className="h-6 w-6 mb-1" />
-            <span className="text-xs">画像選択</span>
-          </Button>
-        )}
-        <input
-          type="file"
-          accept="image/*"
-          ref={itemImageInputRef}
-          onChange={onFileChange}
-          className="hidden"
+            <div className="relative">
+              <Combobox.Input
+                className="w-full bg-background font-medium"
+                placeholder={`${index + 1}位のアイテム名*`}
+                value={itemQuery}
+                onChange={(e) => setItemQuery(e.target.value)}
+                displayValue={() => item.itemName}
+                maxLength={100}
+                disabled={isSaving}
+                onFocus={() => subject && setSuggestEnabled(true)}
+              />
+              <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+                <ChevronsUpDown className="h-5 w-5 text-muted-foreground" />
+              </Combobox.Button>
+              <Combobox.Options className="absolute z-10 mt-1 w-full bg-popover shadow-md max-h-60 overflow-auto rounded-md">
+                {isItemLoading && <div className="p-2">読み込み中…</div>}
+                {!isItemLoading && itemOptions.length === 0 && (
+                  <div className="p-2 text-muted-foreground">該当なし</div>
+                )}
+                {itemOptions.map((opt) => (
+                  <Combobox.Option
+                    key={opt}
+                    value={opt}
+                    className={({ active }) =>
+                      `cursor-pointer select-none p-2 ${
+                        active ? "bg-primary text-primary-foreground" : ""
+                      }`
+                    }
+                  >
+                    {opt}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
+            </div>
+          </Combobox>
+          <Textarea
+            value={item.itemDescription ?? ""}
+            onChange={(e) =>
+              handleItemChange(clientId, "itemDescription", e.target.value)
+            }
+            placeholder="アイテムの説明・コメント（任意）"
+            rows={2}
+            maxLength={500}
+            className="text-sm bg-background"
+            disabled={isSaving}
+          />
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => handleDeleteItem(clientId)}
           disabled={isSaving}
-        />
-      </div>
-
-      {/* アイテム入力 */}
-      <div className="flex-1 space-y-1 pt-1">
-        {/* アイテム名オートコンプ */}
-        <Combobox
-          value={item.itemName}
-          onChange={(val: string) => {
-            handleItemChange(clientId, "itemName", val);
-            setItemQuery(val);
-          }}
+          className="self-start mt-1 text-muted-foreground hover:text-destructive"
+          title="アイテム削除"
         >
-          <div className="relative">
-            <Combobox.Input
-              className="w-full bg-background font-medium"
-              placeholder={`${index + 1}位のアイテム名*`}
-              value={itemQuery}
-              onChange={(e) => setItemQuery(e.target.value)}
-              displayValue={() => item.itemName}
-              maxLength={100}
-              disabled={isSaving}
-              // フォーカス時に候補取得を有効化
-              onFocus={() => {
-                if (subject) setSuggestEnabled(true);
-              }}
-            />
-            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-              <ChevronsUpDown className="h-5 w-5 text-muted-foreground" />
-            </Combobox.Button>
-            <Combobox.Options className="absolute z-10 mt-1 w-full bg-popover shadow-md max-h-60 overflow-auto rounded-md">
-              {isItemLoading && <div className="p-2">読み込み中…</div>}
-              {!isItemLoading && itemOptions.length === 0 && (
-                <div className="p-2 text-muted-foreground">該当なし</div>
-              )}
-              {itemOptions.map((opt) => (
-                <Combobox.Option
-                  key={opt}
-                  value={opt}
-                  className={({ active }) =>
-                    `cursor-pointer select-none p-2 ${
-                      active ? "bg-primary text-primary-foreground" : ""
-                    }`
-                  }
-                >
-                  {opt}
-                </Combobox.Option>
-              ))}
-            </Combobox.Options>
-          </div>
-        </Combobox>
-        {/* アイテム説明入力 */}
-        <Textarea
-          value={item.itemDescription ?? ""}
-          onChange={(e) =>
-            handleItemChange(clientId, "itemDescription", e.target.value)
-          }
-          placeholder="アイテムの説明・コメント（任意）"
-          rows={2}
-          maxLength={500}
-          className="text-sm bg-background"
-          disabled={isSaving}
-        />
+          <TrashIcon className="h-4 w-4" />
+        </Button>
       </div>
-
-      {/* アイテム削除 */}
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={() => handleDeleteItem(clientId)}
-        disabled={isSaving}
-        className="mt-1 text-muted-foreground hover:text-destructive"
-        title="アイテム削除"
-      >
-        <TrashIcon className="h-4 w-4" />
-      </Button>
     </li>
   );
 };


### PR DESCRIPTION
<li> に flex-col sm:flex-row を指定し、小画面では縦レイアウトに

1行目・2行目をそれぞれ <div> に分割

2行目も flex-col sm:flex-row として、スマホで縦、広い画面で横並びに切り替え

これでスマホ時に下段テキスト部分の幅を確保し、可読性が改善されます。